### PR TITLE
Use named transitions for commit circles

### DIFF
--- a/js/historyview.js
+++ b/js/historyview.js
@@ -488,7 +488,7 @@ define(['d3'], function () {
                 })
                 .call(fixCirclePosition)
                 .attr('r', 1)
-                .transition()
+                .transition("inflate")
                 .duration(500)
                 .attr('r', this.commitRadius);
 

--- a/js/main.js
+++ b/js/main.js
@@ -45,7 +45,7 @@ if (!Array.prototype.indexOf) {
 
 require.config({
     paths: {
-        'd3': 'https://cdnjs.cloudflare.com/ajax/libs/d3/3.0.8/d3.min'
+        'd3': 'https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.12/d3.min'
     },
     shim: {
         'd3': {


### PR DESCRIPTION
Use named transitions for the commit circles to prevent later transitions from interrupting earlier ones. This requires the version of D3 to be updated to version 3.5+.

Fixes #39.

References:
* [D3 v3.5 release notes](https://github.com/mbostock/d3/releases/tag/v3.5.0)
* [Named transitions I](http://bl.ocks.org/mbostock/5d8039fb983a29e2ad49)
* [Named transitions II](http://bl.ocks.org/mbostock/24bdd02df2a72866b0ec)
* [D3.js: Stop transitions being interrupted?](http://stackoverflow.com/q/16335781/1538531)