### PR TITLE
Fixes #61: multiple spaces cause empty elements on split(' '). 

### DIFF
--- a/js/controlbox.js
+++ b/js/controlbox.js
@@ -105,7 +105,7 @@ define(['d3'], function () {
                 return;
             }
 
-            var split = entry.split(' ');
+            var split = entry.split(' ').filter(function(elm) { return elm !== ''; });
 
             this.log.append('div')
                 .classed('command-entry', true)


### PR DESCRIPTION
use filter to remove empty elements

Fixes #61 