### PR TITLE
Expired link to "git reset" documentation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
       <p>
         This command is normally used with one of three flags: "--soft", "--mixed", and "--hard".
         The soft and mixed flags deal with what to do with the work that was inside the commit after
-        you reset, and you can read about it <a href="http://git-scm.com/2011/07/11/reset.html">here</a>.
+        you reset, and you can read about it <a href="https://git-scm.com/book/en/v2/Git-Tools-Reset-Demystified">here</a>.
         Since this visualization cannot graphically display that work, only the "--hard" flag will work
         on this site.
       </p>


### PR DESCRIPTION
New link will direct to newest GIT documentation of "git reset" command.